### PR TITLE
fix program call without custom regex and format

### DIFF
--- a/logmerge.py
+++ b/logmerge.py
@@ -178,13 +178,16 @@ def main():
     if args.logfiles is None or len(args.logfiles) < 2:
         print("Requires at least two logfiles")
         exit(1)
-    elif not args.format ^ args.regex:
+    elif bool(args.format) != bool(args.regex):
         print("Requires both timestamp regex and format or none")
         exit(1)
 
     global custom_pattern, custom_format
-    custom_pattern = re.compile(args.regex.encode().decode('unicode_escape'))
-    custom_format = args.format
+    if args.regex:
+        custom_pattern = re.compile(args.regex.encode().decode('unicode_escape'))
+        custom_format = args.format
+    else:
+        custom_pattern, custom_format = None, None
 
     prefixes = collections.defaultdict(lambda: '')
     colorize = args.colorize if sys.stdout.isatty() else False


### PR DESCRIPTION
calling program with custom regex and format like,
```
python3 logmerge.py tests/f1 tests/f2
```
resulted in
```
Traceback (most recent call last):
  File "logmerge.py", line 213, in <module>
    main()
  File "logmerge.py", line 181, in main
    elif not args.format ^ args.regex:
TypeError: unsupported operand type(s) for ^: 'NoneType' and 'NoneType'
```

Bug introduced in 53ff53e and #8, authored by me. Sorry.